### PR TITLE
Add a Task to upgrade the OTel Demp Chart

### DIFF
--- a/otel-demo-overrides.yaml
+++ b/otel-demo-overrides.yaml
@@ -53,7 +53,24 @@ components:
     enabled: false
 
   flagd:
-    enabled: false
+    enabled: true
+    sidecarContainers:
+      - name: flagd-ui
+        useDefault:
+          env: true
+        service:
+          port: 4000
+        env:
+          - name: FLAGD_METRICS_EXPORTER
+            value: otel
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://$(OTEL_COLLECTOR_NAME):4318
+        resources:
+          limits:
+            memory: 300Mi
+        volumeMounts:
+          - name: config-rw
+            mountPath: /app/data
 
   kafka:
     enabled: false

--- a/tasks/otel.yaml
+++ b/tasks/otel.yaml
@@ -35,6 +35,8 @@ tasks:
     deps:
       - task: cluster:start
       - task: tools:install-helm
+    status:
+      - "{{ .HELM_CMD }} list --namespace otel-demo -o json | jq -r '.[].status' | grep -q deployed"
     cmds:
       - "{{ .HELM_CMD }} repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
       - "{{ .HELM_CMD }} install --values otel-demo-overrides.yaml my-otel-demo open-telemetry/opentelemetry-demo --namespace otel-demo --create-namespace"

--- a/tasks/otel.yaml
+++ b/tasks/otel.yaml
@@ -35,11 +35,19 @@ tasks:
     deps:
       - task: cluster:start
       - task: tools:install-helm
-    status:
-      - "{{ .HELM_CMD }} list --namespace otel-demo -o json | jq -r '.[].status' | grep -q deployed"
     cmds:
       - "{{ .HELM_CMD }} repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
       - "{{ .HELM_CMD }} install --values otel-demo-overrides.yaml my-otel-demo open-telemetry/opentelemetry-demo --namespace otel-demo --create-namespace"
+
+  demo-upgrade:
+    desc: Upgrade otel-demo in the local cluster.
+    run: once
+    deps:
+      - task: cluster:start
+      - task: tools:install-helm
+    cmds:
+      - "{{ .HELM_CMD }} repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
+      - "{{ .HELM_CMD }} upgrade --install --values otel-demo-overrides.yaml my-otel-demo open-telemetry/opentelemetry-demo --namespace otel-demo --create-namespace"
 
   demo-status:
     desc: Check the status of otel-demo in the local cluster.


### PR DESCRIPTION
- Add a Task to upgrade the OTel Demo Chart. It's needed when you change the override values and want to apply them to your current deployment
- Enable flagd - without it product catalog does not work
- Change the flagd-ui memory limit, it seem to crash on a local k3d cluster with the default settings